### PR TITLE
PHP Version check

### DIFF
--- a/.github/php-syntax.json
+++ b/.github/php-syntax.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "php -l",
+      "pattern": [
+        {
+          "regexp": "^\\s*(PHP\\s+)?([a-zA-Z\\s]+):\\s+(.*)\\s+in\\s+(\\S+)\\s+on\\s+line\\s+(\\d+)$",
+          "file": 4,
+          "line": 5,
+          "message": 3
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,26 @@
+name: PHP
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  syntax:
+    name: "Check Syntax (${{ matrix.php }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+        - '7.4'
+        - '8.0'
+        - '8.1'
+    steps:
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+    - uses: actions/checkout@v3
+    - run: echo "::add-matcher::.github/php-syntax.json"
+    - run: |
+        ! find . -type f -name '*.php' -exec php -l '{}' \; 2>&1 |grep -v '^No syntax errors detected'


### PR DESCRIPTION
Ich habe einen GitHub workflow eingebaut, welcher prüft ob das Plugin unter PHP 7.4, PHP 8.0 und PHP 8.1 lauffähig ist.

Ich habe mich dabei an den [Supported Versions](https://www.php.net/supported-versions.php) orientiert.